### PR TITLE
config: Create archive directory if it does not exist

### DIFF
--- a/chat_archive/__init__.py
+++ b/chat_archive/__init__.py
@@ -23,7 +23,7 @@ from verboselogs import VerboseLogger
 from chat_archive.backends import ChatArchiveBackend
 from chat_archive.database import SchemaManager
 from chat_archive.models import Account, Base, Contact, Conversation, EmailAddress, Message
-from chat_archive.utils import get_full_name
+from chat_archive.utils import get_full_name, ensure_directory_exists
 
 DEFAULT_ACCOUNT_NAME = "default"
 """The name of the default account (a string)."""
@@ -118,9 +118,7 @@ class ChatArchive(SchemaManager):
         expanded to the profile directory of the current user).
         """
         path = parse_path(os.environ.get("CHAT_ARCHIVE_DIRECTORY", "~/.local/share/chat-archive"))
-
-        if not os.path.exists(path):
-            os.mkdir(path)
+        ensure_directory_exists(path)
 
         return path
 

--- a/chat_archive/__init__.py
+++ b/chat_archive/__init__.py
@@ -117,7 +117,12 @@ class ChatArchive(SchemaManager):
         default value ``~/.local/share/chat-archive`` is used (where ``~`` is
         expanded to the profile directory of the current user).
         """
-        return parse_path(os.environ.get("CHAT_ARCHIVE_DIRECTORY", "~/.local/share/chat-archive"))
+        path = parse_path(os.environ.get("CHAT_ARCHIVE_DIRECTORY", "~/.local/share/chat-archive"))
+
+        if not os.path.exists(path):
+            os.mkdir(path)
+
+        return path
 
     @mutable_property
     def database_file(self):


### PR DESCRIPTION
If "~/.local/share/chat-archive" (or some other directory defined by `$CHAT_ARCHIVE_DIRECTORY` is not created), the sqlite backend explodes:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/chat_archive/cli.py", line 190, in main
    with UserInterface(**program_opts) as program:
  File "/usr/local/lib/python3.6/site-packages/chat_archive/database.py", line 106, in __init__
    first_run = self.current_schema_revision is None
  File "/usr/local/lib/python3.6/site-packages/property_manager/__init__.py", line 781, in __get__
    value = super(custom_property, self).__get__(obj, type)
  File "/usr/local/lib/python3.6/site-packages/chat_archive/database.py", line 159, in current_schema_revision
    context = MigrationContext.configure(self.database_engine.connect())
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/engine/base.py", line 2102, in connect
    return self._connection_cls(self, **kwargs)
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/engine/base.py", line 90, in __init__
    if connection is not None else engine.raw_connection()
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/engine/base.py", line 2188, in raw_connection
    self.pool.unique_connection, _connection)
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/engine/base.py", line 2162, in _wrap_pool_connect
    e, dialect, self)
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/engine/base.py", line 1476, in _handle_dbapi_exception_noconnection
    exc_info
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/util/compat.py", line 265, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/util/compat.py", line 248, in reraise
    raise value.with_traceback(tb)
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/engine/base.py", line 2158, in _wrap_pool_connect
    return fn()
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/pool.py", line 345, in unique_connection
    return _ConnectionFairy._checkout(self)
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/pool.py", line 791, in _checkout
    fairy = _ConnectionRecord.checkout(pool)
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/pool.py", line 532, in checkout
    rec = pool._do_get()
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/pool.py", line 1287, in _do_get
    return self._create_connection()
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/pool.py", line 350, in _create_connection
    return _ConnectionRecord(self)
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/pool.py", line 477, in __init__
    self.__connect(first_connect_check=True)
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/pool.py", line 674, in __connect
    connection = pool._invoke_creator(self)
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/engine/strategies.py", line 106, in connect
    return dialect.connect(*cargs, **cparams)
  File "/usr/local/lib64/python3.6/site-packages/sqlalchemy/engine/default.py", line 412, in connect
    return self.dbapi.connect(*cargs, **cparams)
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file (Background on this error at: http://sqlalche.me/e/e3q8)
```